### PR TITLE
Translations

### DIFF
--- a/src/ui/FavoriteButton.js
+++ b/src/ui/FavoriteButton.js
@@ -3,6 +3,7 @@ import {RenameWindow} from './RenameWindow.js';
 import {SharingWindow} from './SharingWindow.js';
 import {InterpretationWindow} from './InterpretationWindow.js';
 import {LinkWindow} from './LinkWindow.js';
+import {TranslateWindow} from './TranslateWindow.js';
 
 export var FavoriteButton;
 
@@ -98,6 +99,16 @@ FavoriteButton = function(c) {
                     });
                     uiManager.reg(saveAsItem, 'renameItem');
                     
+                    var translateItem = Ext.create('Ext.menu.Item', {		
+                        text: getTitle(i18n.translate),		
+                        iconCls: 'ns-menu-item-favorite-translate',		
+                        disabled: !instanceManager.isStateFavorite(),		
+                        handler: function() {		
+                            TranslateWindow(c, instanceManager.getStateFavorite()).show();		
+                        }		
+                    });		
+                    uiManager.reg(saveAsItem, 'translateItem');
+
                     var shareItem = Ext.create('Ext.menu.Item', {
                         text: getTitle(i18n.share),
                         iconCls: 'ns-menu-item-favorite-share',
@@ -165,6 +176,7 @@ FavoriteButton = function(c) {
                         //discardItem,
                         //'-',
                         renameItem,
+                        translateItem,
                         '-',
                         shareItem,
                         interpretationItem,

--- a/src/ui/FavoriteTextCmp.js
+++ b/src/ui/FavoriteTextCmp.js
@@ -43,8 +43,34 @@ export default function({ layout, i18n }) {
         value: layout.description
     });
 
+    const titleTextField = Ext.create('Ext.form.field.Text', {		
+        width: fs.windowCmpWidth,		
+        height: 45,		
+        style: 'margin-bottom: 0',		
+        fieldStyle: fs.textfieldStyle.join(';'),		
+        fieldLabel: i18n.title,		
+        labelAlign: 'top',		
+        labelStyle: fs.textFieldLabelStyle.join(';'),		
+        labelSeparator: '',		
+        emptyText: 'No title (optional)',		
+        enableKeyEvents: true,		
+        currentValue: '',		
+        value: layout.title,		
+        setEventKeyUpHandler: function(handler) {		
+            this.eventKeyUpHandler = handler;		
+        },		
+        listeners: {		
+            keyup: function(cmp, e) {		
+                if (e.keyCode === 13 && this.eventKeyUpHandler) {		
+                    this.eventKeyUpHandler(cmp, e);		
+                }		
+            }		
+        }		
+    });
+
     return {
         nameTextField,
-        descriptionTextField
+        descriptionTextField,
+        titleTextField
     };
 }

--- a/src/ui/TranslateTextCmp.js
+++ b/src/ui/TranslateTextCmp.js
@@ -1,0 +1,36 @@
+import getFavoriteTextCmp from './FavoriteTextCmp';
+
+export default function({ layout, i18n }) {
+
+    // Load Favorite textfield
+    const { nameTextField, titleTextField, descriptionTextField } = getFavoriteTextCmp({ layout, i18n });
+    
+    // Customise them for translate Panel
+    delete nameTextField.height;
+    delete titleTextField.height;
+    delete descriptionTextField.height;
+
+    titleTextField.emptyText = 'No title';
+    descriptionTextField.emptyText = 'No description';
+
+    // Create labels for keys
+    var getLabelKey = function(text) {
+        return Ext.create('Ext.form.Label', {
+            style: 'font-size: 11px;color: #111;padding-left: 7px;padding-top: 4px;margin-bottom: 0',
+            text: text
+        });
+    };
+
+    const nameLabelKey = getLabelKey(layout.name);
+    const titleLabelKey = getLabelKey(layout.title);
+    const descriptionLabelKey = getLabelKey(layout.description);
+
+    return {
+        nameTextField,
+        nameLabelKey,
+        titleTextField,
+        titleLabelKey,
+        descriptionTextField,
+        descriptionLabelKey
+    };
+}

--- a/src/ui/TranslateTextCmp.js
+++ b/src/ui/TranslateTextCmp.js
@@ -3,15 +3,27 @@ import getFavoriteTextCmp from './FavoriteTextCmp';
 export default function({ layout, i18n }) {
 
     // Load Favorite textfield
-    const { nameTextField, titleTextField, descriptionTextField } = getFavoriteTextCmp({ layout, i18n });
+    const { nameTextField, descriptionTextField, titleTextField } = getFavoriteTextCmp({ layout, i18n });
     
     // Customise them for translate Panel
     delete nameTextField.height;
     delete titleTextField.height;
     delete descriptionTextField.height;
 
-    titleTextField.emptyText = 'No title';
-    descriptionTextField.emptyText = 'No description';
+    if (!layout.title || layout.title == ''){
+        titleTextField['disabled'] = true;
+        titleTextField.emptyText = 'No title';
+    }
+    else{
+        titleTextField.emptyText = 'No translation for title';
+    }
+    if (!layout.description || layout.description == ''){
+        descriptionTextField['disabled'] = true;
+        descriptionTextField.emptyText = 'No description';
+    }
+    else{
+        descriptionTextField.emptyText = 'No translation for description';
+    }
 
     // Create labels for keys
     var getLabelKey = function(text) {

--- a/src/ui/TranslateWindow.js
+++ b/src/ui/TranslateWindow.js
@@ -1,0 +1,130 @@
+import isArray from 'd2-utilizr/lib/isArray';
+
+import getFavoriteTextCmp from './FavoriteTextCmp';
+import fs from './FavoriteStyle';
+
+export var TranslateWindow;
+
+TranslateWindow = function(refs, layout, fn, listeners) {
+    var t = this,
+
+        appManager = refs.appManager,
+        uiManager = refs.uiManager,
+        instanceManager = refs.instanceManager,
+        i18n = refs.i18nManager.get(),
+        uiConfig = refs.uiConfig,
+        api = refs.api,
+
+        path = appManager.getPath(),
+        apiResource = instanceManager.apiResource;
+
+    listeners = listeners || {};
+
+    //const { nameTextField, titleTextField, descriptionTextField } = getFavoriteTextCmp({ layout, i18n });
+    var states = Ext.create('Ext.data.Store', {
+        fields: ['abbr', 'name'],
+        data : [
+            {"abbr":"AL", "name":"Alabama"},
+            {"abbr":"AK", "name":"Alaska"},
+            {"abbr":"AZ", "name":"Arizona"}
+            //...
+        ]
+    });
+
+
+    var localeComboBox = Ext.create('Ext.form.ComboBox', {
+        fieldLabel: 'Choose State',
+        store: states,
+        queryMode: 'local',
+        displayField: 'name',
+        valueField: 'abbr',
+        renderTo: Ext.getBody()
+    });
+
+    var saveButton = Ext.create('Ext.button.Button', {
+        text: i18n.save,
+        handler: function() {
+            var name = nameTextField.getValue(),
+                title = titleTextField.getValue(),
+                description = descriptionTextField.getValue(),
+                put = function() {
+                    layout.clone().put(function() {
+                        if (fn) {
+                            fn();
+                        }
+                        instanceManager.setStateIf(layout, true);
+                        window.destroy();
+                    }, true, true);
+                };
+
+            if (layout.put) {
+                layout.name = name;
+                layout.title = title;
+                layout.description = description;
+                put();
+            }
+            else {
+                var fields = appManager.getAnalysisFields(),
+                    url = path + '/api/' + apiResource + '/' + layout.id + '.json?fields=' + fields;
+
+                $.getJSON(encodeURI(url), function(r) {
+                    layout = new api.Layout(refs, r).val();
+                    layout.name = name;
+                    layout.title = title;
+                    layout.description = description;
+
+                    put();
+                });
+            }
+        }
+    });
+
+    var cancelButton = Ext.create('Ext.button.Button', {
+        text: i18n.cancel,
+        handler: function() {
+            window.destroy();
+        }
+    });
+
+    var window = Ext.create('Ext.window.Window', {
+        title: 'Translate',
+        bodyStyle: 'padding:1px; background:#fff',
+        resizable: false,
+        modal: true,
+        items: [
+            localeComboBox
+        ],
+        destroyOnBlur: true,
+        bbar: [
+            cancelButton,
+            '->',
+            saveButton
+        ],
+        listeners: {
+            show: function(w) {
+                var favoriteButton = uiManager.get('favoriteButton') || {};
+
+                if (favoriteButton.rendered) {
+                    uiManager.setAnchorPosition(w, favoriteButton);
+
+                    if (!w.hasDestroyOnBlurHandler) {
+                        uiManager.addDestroyOnBlurHandler(w);
+                    }
+                }
+
+                nameTextField.focus(false, 500);
+
+                if (listeners.show) {
+                    listeners.show();
+                }
+            },
+            destroy: function() {
+                if (listeners.destroy) {
+                    listeners.destroy();
+                }
+            }
+        }
+    });
+
+    return window;
+};

--- a/src/ui/TranslateWindow.js
+++ b/src/ui/TranslateWindow.js
@@ -67,13 +67,13 @@ TranslateWindow = function(refs, layout, fn, listeners) {
     });
 
     var localeComboBox = Ext.create('Ext.form.ComboBox', {
-        width: fs.windowCmpWidth,
+        width: fs.windowCmpWidth * 0.9,
         height: 45,
-        style: 'margin-top: 2px; margin-bottom: 0',
-        fieldStyle: fs.textfieldStyle.join(';'),
+        style: 'margin-top: 2px; margin-bottom: 0;margin-left:5px;',
+        fieldStyle: 'padding-right:0;padding-left:5px;font-size:11px;line-height:13px;',
         fieldLabel: 'Select a locale to enter translations for ',
         labelAlign: 'top',
-        labelStyle: fs.textFieldLabelStyle.join(';'),
+        labelStyle: 'font-size:11px;font-weight:bold;color:#111;padding-top:4px;margin-bottom:2px',
         labelSeparator: '',
         store: localeStore,
         queryMode: 'local',
@@ -141,9 +141,6 @@ TranslateWindow = function(refs, layout, fn, listeners) {
                 }
             }
 
-            console.log('Object to push')
-            console.log(newTranslations)
-
             // Update server with translations
             $.ajax({
                 url: encodeURI(path + '/api/' + apiEndpoint + '/' + layout.id + '/translations/'),
@@ -192,8 +189,6 @@ TranslateWindow = function(refs, layout, fn, listeners) {
                     disableCaching: false,
                     success: function(r) {
                        translations = Ext.decode(r.responseText).translations
-                       console.log("currentTranslations");
-                       console.log(translations);
                     }
                 });
 


### PR DESCRIPTION
@janhenrikoverland I have readded titleTextField to FavoriteTextCmp. I think it is a good idea name, title and description fields have the same look&feel and to have the three components in the same file enforce this idea. It doesn't change the current behaviour for rename (just name and description). However it can also go to TranslateTextCmp that is the equivalent file I created for the translate window.

As discussed, title and description components will be disabled when no title/description is set...

PR for pivot and chart coming soon...