### PR TITLE
Interpretation and sharing improvements

### DIFF
--- a/src/api/Layout.js
+++ b/src/api/Layout.js
@@ -123,6 +123,11 @@ Layout = function(refs, c, applyConfig, forceApplyConfig) {
         t.publicAccess = c.publicAccess;
     }
 
+        //permission
+    if (isString(c.permission)) {
+        t.permission = c.permission;
+    }
+
         //user group accesses
     if (arrayFrom(c.userGroupAccesses).length) {
         t.userGroupAccesses = c.userGroupAccesses;
@@ -424,6 +429,7 @@ Layout.prototype.toPlugin = function(el) {
             'created',
             'user',
             'publicAccess',
+            'permission',
             'userGroupAccesses',
             'prototype',
             'url'
@@ -526,6 +532,7 @@ Layout.prototype.toPostSuper = function() {
     delete this.created;
     delete this.user;
     delete this.publicAccess;
+    delete this.permission,
     delete this.userGroupAccesses;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ import { IntegrationButton } from './ui/IntegrationButton.js';
 
 import { i18nInit } from './init/i18nInit.js';
 import { authViewUnapprovedDataInit } from './init/authViewUnapprovedDataInit.js';
+import { isAdminInit } from './init/isAdminInit.js';
 import { rootNodesInit } from './init/rootNodesInit.js';
 import { organisationUnitLevelsInit } from './init/organisationUnitLevelsInit.js';
 import { legendSetsInit } from './init/legendSetsInit.js';
@@ -101,6 +102,7 @@ export {
 
     i18nInit,
     authViewUnapprovedDataInit,
+    isAdminInit,
     rootNodesInit,
     organisationUnitLevelsInit,
     legendSetsInit,
@@ -170,6 +172,7 @@ export const ui = {
 export const init = {
     i18nInit,
     authViewUnapprovedDataInit,
+    isAdminInit,
     rootNodesInit,
     organisationUnitLevelsInit,
     legendSetsInit,

--- a/src/init/isAdminInit.js
+++ b/src/init/isAdminInit.js
@@ -1,0 +1,16 @@
+export var isAdminInit;
+
+isAdminInit = function(c) {
+    var t = this,
+        appManager = c.appManager,
+        requestManager = c.requestManager,
+        apiPath = appManager.getApiPath();
+
+    return {
+        baseUrl: appManager.getPath() + '/api/me/authorization/ALL', 
+        success: function(r) {
+            appManager.isAdmin = r;
+            requestManager.ok(this);
+        }
+    };
+};

--- a/src/manager/AppManager.js
+++ b/src/manager/AppManager.js
@@ -38,7 +38,7 @@ AppManager = function(refs) {
 
     t.defaultAnalysisFields = [
         '*',
-        'interpretations[*,user[id,displayName],likedBy[id,displayName],comments[lastUpdated,text,user[id,displayName]]]',
+        'interpretations[*,user[id,displayName],likedBy[id,displayName],comments[id,lastUpdated,text,user[id,displayName]]]',
         'columns[dimension,filter,items[dimensionItem~rename(id),dimensionItemType,$]]',
         'rows[dimension,filter,items[dimensionItem~rename(id),dimensionItemType,$]]',
         'filters[dimension,filter,items[dimensionItem~rename(id),dimensionItemType,$]]',

--- a/src/manager/UiManager.js
+++ b/src/manager/UiManager.js
@@ -464,6 +464,18 @@ UiManager = function(refs) {
         ConfirmWindow(refs, title, i18n.this_favorite_will_be_deleted_continue, null, fn).show();
     };
 
+    t.confirmInterpretationDelete = function(fn) {
+        var i18n = t.i18nManager ? t.i18nManager.get() : {};
+        ConfirmWindow(refs, i18n.are_you_sure, 
+            i18n.this_interpretation_will_be_deleted_continue, null, fn).show();
+    };
+
+    t.confirmCommentDelete = function(fn) {
+        var i18n = t.i18nManager ? t.i18nManager.get() : {};
+        ConfirmWindow(refs, i18n.are_you_sure, 
+            i18n.this_comment_will_be_deleted_continue, null, fn).show();
+    };
+
     // redirect
     t.redirectCtrl = function(url, e) {
         if (e.button === 0 && !e.ctrlKey) {

--- a/src/ui/EastRegion.js
+++ b/src/ui/EastRegion.js
@@ -19,7 +19,22 @@ EastRegion = function(c) {
         path = appManager.getPath(),
         apiPath = appManager.getApiPath();
 
-    var descriptionMaxNumberCharacter = 200;
+    var descriptionMaxNumberCharacter = 500;
+
+    var openInterpretationWindow = function(id, interpretation, success) {
+        var favoriteId = id || instanceManager.getStateFavoriteId();
+        instanceManager.getSharingById(favoriteId, function(r) {
+            InterpretationWindow(c, r, interpretation, success).show();
+        }, {allowForbidden: true});
+    };
+
+    var userCanManageInterpretation = function(interpretation) {
+        return interpretation.user.id == appManager.userAccount.id || appManager.isAdmin;
+    };
+
+    var userCanManageComment = function(comment) {
+        return comment.user.id == appManager.userAccount.id || appManager.isAdmin;
+    };
 
     var getLink = function(text, isBold, isBrackets) {
         return (isBrackets ? '<span class="bold">[</span> ' : '') +
@@ -58,7 +73,7 @@ EastRegion = function(c) {
                     cls: 'interpretationActions'
                 });
 
-                // Longer than 200 characters -> Create More/Less link
+                // Longer than [descriptionMaxNumberCharacter] characters -> Create More/Less link
                 if (isTooLongDescription) {
                     var longDescription = description;
 
@@ -87,19 +102,21 @@ EastRegion = function(c) {
                 }
 
                 // Change Link
-                descriptionItems.push({
-                    xtype: 'label',
-                    html: getLink(editText, false, true),
-                    cls: 'interpretationActions',
-                    style: 'margin: 1px 3px 0;',
-                    listeners: {
-                        'render': function(label) {
-                            label.getEl().on('click', function() {
-                                RenameWindow(c, instanceManager.getStateFavorite()).show();
-                            }, label);
+                if (layout && layout.permission === "write") {
+                    descriptionItems.push({
+                        xtype: 'label',
+                        html: getLink(editText, false, true),
+                        cls: 'interpretationActions',
+                        style: 'margin: 1px 3px 0;',
+                        listeners: {
+                            'render': function(label) {
+                                label.getEl().on('click', function() {
+                                    RenameWindow(c, instanceManager.getStateFavorite()).show();
+                                }, label);
+                            }
                         }
-                    }
-                });
+                    });
+                }
 
                 return descriptionItems;
             };
@@ -148,6 +165,8 @@ EastRegion = function(c) {
             }
 
             // Favorite Details Panel content when favorite loaded
+            var userCanEditSharing = layout && layout.permission === 'write';
+
             detailsPanelItems = [{
                 xtype: 'panel',
                 itemId: 'descriptionPanel',
@@ -197,16 +216,19 @@ EastRegion = function(c) {
                 fieldLabel: i18n.sharing,
                 labelStyle: 'padding-top:0',
                 style: 'margin-bottom:3px',
-                value: getSharingText(layout) + '<span style="padding-left:10px">' + getLink(editText, false, true) + '</span>',
+                value: getSharingText(layout) + (userCanEditSharing ? 
+                    '<span style="padding-left:10px">' + getLink(editText, false, true) + '</span>' : ''),
                 cls: 'interpretationDetailsField',
                 listeners: {
                     'render': function(label) {
-                        label.getEl().on('click', function() {
-                            instanceManager.getSharingById(instanceManager.getStateFavoriteId(), function(r)  {
-                                SharingWindow(c, r).show();
-                            });
-                        }, label);
-                    }
+                        if (userCanEditSharing) {
+                            label.getEl().on('click', function() {
+                                instanceManager.getSharingById(instanceManager.getStateFavoriteId(), function(r) {
+                                    SharingWindow(c, r).show();
+                                });
+                            }, label);
+                        }
+                    } 
                 }
             }];
         } else {
@@ -255,22 +277,17 @@ EastRegion = function(c) {
      */
 
     // Create interpretation panel depending on interpretation
-    var getInterpretationPanel = function(interpretation, displayingComments) {
+    var getInterpretationPanel = function(layout, interpretation, displayingComments) {
 
         var numberOfCommentsToDisplay = 3;
 
-        // Create inner comments panel depending on comments
-        var getCommentsPanel = function(comments) {
-
-            var commentsPanel = [];
-
-            // Textarea to comment
-            commentsPanel.push({
+        var getWriteCommentBox = function(comment, visible) {
+            return {
                 xtype: 'panel',
                 bodyStyle: 'border-style:none',
                 layout: 'column',
-                itemId: 'commentPanel',
-                hidden: true,
+                itemId: 'commentPanel-' + (comment ? comment.id : "new"),
+                hidden: !visible || (!layout || layout.permission === "none"),
                 style: 'margin-top: 1px;',
                 cls: 'comment greyBackground',
                 items: [{
@@ -293,6 +310,7 @@ EastRegion = function(c) {
                         itemId: 'commentArea',
                         cls: 'commentArea',
                         emptyText: i18n.write_your_interpretation,
+                        value : comment && comment.text,
                         submitEmptyText: false,
                         flex: 1,
                         border: 0,
@@ -300,35 +318,65 @@ EastRegion = function(c) {
                         listeners: {
                             keypress: function(f, e) {
                                 if (e.getKey() == e.ENTER && !e.shiftKey) {
-                                    commentInterpretation(f);
+                                    commentInterpretation(f, comment);
                                 }
                             }
                         }
                     }, {
-                        xtype: 'label',
-                        html: getLink(i18n.post_comment),
-                        cls: 'link',
-                        listeners: {
-                            'render': function(label) {
-                                label.getEl().on('click', function() {
-                                    commentInterpretation(this.up("[xtype='panel']").down('#commentArea'))
-                                }, label);
+                        xtype: 'panel',
+                        bodyStyle: 'border-style:none',
+                        items: [{
+                            xtype: 'label',
+                            html: getLink(i18n.post_comment),
+                            cls: 'link',
+                            listeners: {
+                                'render': function(label) {
+                                    label.getEl().on('click', function() {
+                                        commentInterpretation(this.up("panel").up("panel").down('#commentArea'), comment)
+                                    }, label);
+                                }
                             }
-                        }
+                        }, {
+                            xtype: 'label',
+                            text: '·',
+                            hidden: !comment,
+                            style: 'margin-left: 5px; margin-right: 5px;'
+                        }, {
+                            xtype: 'label',
+                            html: getLink(i18n.cancel),
+                            hidden: !comment,
+                            cls: 'link',
+                            listeners: {
+                                'render': function(label) {
+                                    label.getEl().on('click', function() {
+                                        cancelCommentEdit(this, comment);
+                                    }, label);
+                                }
+                            }
+                        }]
                     }],
                     columnWidth: 0.89
                 }]
-            });
+            };
+        };
+
+        // Create inner comments panel depending on comments
+        var getCommentsPanel = function(comments) {
+
+            var commentsPanel = [];
+
+            // Textarea to comment
+            commentsPanel.push(getWriteCommentBox(null, true));
 
             // Comments
             // Sorting by last updated
             arraySort(comments, 'DESC', 'lastUpdated');
             for (var i = 0; i < comments.length; i++) {
                 var comment = comments[i];
-
                 commentsPanel.push({
                     xtype: 'panel',
                     bodyStyle: 'border-style:none;',
+                    id: 'commentContent-' + comment.id,
                     cls: 'comment greyBackground',
                     layout: 'column',
                     hidden: (i > numberOfCommentsToDisplay - 1),
@@ -368,10 +416,48 @@ EastRegion = function(c) {
                             xtype: 'label',
                             style: 'color: #666',
                             text: DateManager.getTimeDifference(comment.lastUpdated) + ' ' + i18n.ago
+                        }, {
+                            xtype: 'label',
+                            html: getLink(i18n.edit),
+                            hidden: !userCanManageComment(comment),
+                            style: 'margin-right: 5px; margin-left: 5px',
+                            listeners: {
+                                'render': (function(comment_) {
+                                    return function(label) {
+                                        label.getEl().on('click', function() {
+                                            editComment(this, comment_);
+                                        }, this);
+                                    };
+                                })(comment)
+                            }
+                        }, {
+                            xtype: 'label',
+                            text: '·',
+                            style: 'margin-right: 5px;'
+                        }, {
+                            xtype: 'label',
+                            html: getLink(i18n.delete_),
+                            style: 'margin-right: 5px;',
+                            hidden: !userCanManageComment(comment),
+                            listeners: {
+                                'render': (function(comment_) {
+                                    return function(label) {
+                                        label.getEl().on('click', function() {
+                                            var label = this;
+                                            uiManager.confirmCommentDelete(function() {
+                                                deleteComment(label, comment_);
+                                            });
+                                        }, this);
+                                    };
+                                })(comment)
+                            }
                         }],
                         columnWidth: 0.89
                     }]
                 });
+
+                // Box to edit the comment
+                commentsPanel.push(getWriteCommentBox(comment, false));
             }
 
             // Show more comments
@@ -414,7 +500,8 @@ EastRegion = function(c) {
 
         var refreshInterpretationDataModel = function(interpretationPanel) {
             Ext.Ajax.request({
-                url: encodeURI(apiPath + '/interpretations/' + interpretation.id + '.json?fields=*,user[id,displayName],likedBy[id,displayName],comments[lastUpdated,text,user[id,displayName]]'),
+                url: encodeURI(apiPath + '/interpretations/' + interpretation.id + 
+                    '.json?fields=*,user[id,displayName],likedBy[id,displayName],comments[id,lastUpdated,text,user[id,displayName]]'),
                 method: 'GET',
                 scope: this,
                 success: function(r) {
@@ -448,24 +535,67 @@ EastRegion = function(c) {
         };
 
         // Call comment interpretation, update data model and update/reload panel
-        var commentInterpretation = function(f) {
-            if (f.getValue().trim() != '') {
+        var commentInterpretation = function(f, comment) {
+            var text = f.getValue();
+            
+            if (text.trim() != '') {
+                var commentsUrl = encodeURI(apiPath + '/interpretations/' + interpretation.id + '/comments')
                 Ext.Ajax.request({
-                    url: encodeURI(apiPath + '/interpretations/' + interpretation.id + '/comments'),
-                    method: 'POST',
-                    params: f.getValue(),
+                    url: comment ? commentsUrl + '/' + comment.id : commentsUrl,
+                    method: comment ? 'PUT' : 'POST',
+                    params: text,
                     headers: {
                         'Content-Type': 'text/plain'
                     },
                     success: function() {
-                        // Clear up comment textarea
-                        f.reset();
-
-                        // Refreshing interpretation panel
                         refreshInterpretationDataModel(f.up('#interpretationPanel' + interpretation.id));
                     }
                 });
             }
+        };
+
+        // Update an interpretation update data model and update/reload panel
+        var editInterpretation = function(el) {
+            openInterpretationWindow(null, interpretation, function() {
+                var interpretationPanel = el.up('#interpretationPanel' + interpretation.id);
+                interpretationPanel.updateInterpretationPanelItems(interpretation);
+            });
+        };
+
+        // Delete an interpretation and return to main interpretations panel
+        var deleteInterpretation = function() {
+            Ext.Ajax.request({
+                url: encodeURI(apiPath + '/interpretations/' + interpretation.id),
+                method: 'DELETE',
+                success: function() {
+                    instanceManager.getById(instanceManager.getStateCurrent().id);
+                }
+            });
+        };
+
+        // Delete a comment interpretation, update data model and update/reload panel
+        var deleteComment = function(el, comment) {
+            Ext.Ajax.request({
+                url: encodeURI(apiPath + '/interpretations/' + interpretation.id + '/comments/' + comment.id),
+                method: 'DELETE',
+                success: function() {
+                    refreshInterpretationDataModel(el.up('#interpretationPanel' + interpretation.id));
+                }
+            });
+        };
+
+        var editComment = function(label, comment) {
+            var commentBox = label.up('#commentContent-' + comment.id);
+            var editableCommentBox = commentBox.next();
+            commentBox.hide();
+            editableCommentBox.show();
+        };
+
+        var cancelCommentEdit = function(label, comment) {
+            var editableCommentBox = label.up('#commentPanel-' + comment.id);
+            var commentBox = editableCommentBox.prev();
+            editableCommentBox.hide();
+            commentBox.show();
         };
 
         // Create tooltip for Like link
@@ -531,11 +661,12 @@ EastRegion = function(c) {
                     xtype: 'panel',
                     bodyStyle: 'border-style:none',
                     style: 'margin-bottom: 5px;',
+                    hidden: !layout || layout.permission === "none",
+
                     items: [{
                         xtype: 'label',
                         html: isLiked(interpretation) ? getLink(i18n.unlike) : getLink(i18n.like),
                         style: 'margin-right: 5px;',
-
                         listeners: {
                             'render': function(label) {
                                 label.getEl().on('click', likeUnlikeInterpretation, this);
@@ -552,8 +683,42 @@ EastRegion = function(c) {
                         listeners: {
                             'render': function(label) {
                                 label.getEl().on('click', function() {
-                                    this.up('#interpretationPanel' + interpretation.id).down('#commentPanel').show();
+                                    this.up('#interpretationPanel' + interpretation.id).down('#commentPanel-new').show();
                                     this.up('#interpretationPanel' + interpretation.id).down('#commentArea').focus();
+                                }, this);
+                            }
+                        }
+                    }, {
+                        xtype: 'label',
+                        text: '·',
+                        style: 'margin-right: 5px;'
+                    }, {
+                        xtype: 'label',
+                        html: getLink(i18n.edit),
+                        hidden: !userCanManageInterpretation(interpretation),
+                        style: 'margin-right: 5px;',
+                        listeners: {
+                            'render': function(label) {
+                                label.getEl().on('click', function() {
+                                    editInterpretation(this);
+                                }, this);
+                            }
+                        }
+                    }, {
+                        xtype: 'label',
+                        text: '·',
+                        style: 'margin-right: 5px;'
+                    }, {
+                        xtype: 'label',
+                        html: getLink(i18n.delete_),
+                        hidden: !userCanManageInterpretation(interpretation),
+                        style: 'margin-right: 5px;',
+                        listeners: {
+                            'render': function(label) {
+                                label.getEl().on('click', function() {
+                                    uiManager.confirmInterpretationDelete(function() {
+                                        deleteInterpretation();
+                                    });
                                 }, this);
                             }
                         }
@@ -637,14 +802,14 @@ EastRegion = function(c) {
         return interpretationPanel;
     };
 
-    var getTopInterpretationsPanel = function(interpretations, displayingInterpretation) {
+    var getTopInterpretationsPanel = function(layout, interpretations, displayingInterpretation) {
         var topInterpretationPanelItems = [];
 
         var shareInterpretationPanel = {
             xtype: 'panel',
             bodyStyle: 'border-style:none',
             style: 'padding:6px; border-width:0 0 1px 0; border-style:solid;',
-            hidden: displayingInterpretation,
+            hidden: displayingInterpretation || (!layout || layout.permission === "none"),
             itemId: 'shareInterpretation',
             items: [{
                 xtype: 'label',
@@ -652,11 +817,7 @@ EastRegion = function(c) {
                 cls: 'interpretationActions',
                 listeners: {
                     'render': function(label) {
-                        label.getEl().on('click', function() {
-                            instanceManager.getSharingById(instanceManager.getStateFavoriteId(), function(r) {
-                                InterpretationWindow(c, r).show();
-                            });
-                        }, label);
+                        label.getEl().on('click', function() { openInterpretationWindow() }, label);
                     }
                 }
             }]
@@ -746,13 +907,13 @@ EastRegion = function(c) {
             var interpretationId = layout.interpretationId;
 
             //Get top interpretations panel depending on interpretations and if we are displaying an interpretation
-            this.add(this.getTopInterpretationsPanel(interpretations, interpretationId != undefined));
+            this.add(this.getTopInterpretationsPanel(layout, interpretations, interpretationId != undefined));
 
             // Add an interpretation panel per interpretation
             if (interpretations != undefined && interpretations.length > 0) {
                 for (var i = 0; i < interpretations.length; i++) {
                     if (interpretations[i].id == interpretationId || interpretationId == undefined){
-                        this.add(this.getInterpretationPanel(interpretations[i], (interpretations[i].id == interpretationId)));
+                        this.add(this.getInterpretationPanel(layout, interpretations[i], (interpretations[i].id == interpretationId)));
                     }
                 }
             }
@@ -767,6 +928,7 @@ EastRegion = function(c) {
      */
     return Ext.create('Ext.panel.Panel', {
         region: 'east',
+        openInterpretationWindow: openInterpretationWindow,
         preventHeader: true,
         collapsible: true,
         collapseMode: 'mini',
@@ -777,10 +939,13 @@ EastRegion = function(c) {
         items: [detailsPanel, interpretationsPanel],
         cls: 'eastPanel',
         setState: function(layout) {
-            this.getComponent('detailsPanel').addAndUpdateFavoritePanel(layout);
+            if (layout.interpretations) {
+                this.getComponent('detailsPanel').addAndUpdateFavoritePanel(layout);
 
-            // Favorite loaded with interpretations ->  Add interpretation panel and update
-            this.getComponent('interpretationsPanel').addAndUpdateInterpretationsPanel(layout);
+                // Favorite loaded with interpretations ->  Add interpretation panel and update
+            
+                this.getComponent('interpretationsPanel').addAndUpdateInterpretationsPanel(layout);
+            }
         },
         listeners: {
             expand: function() {

--- a/src/ui/InterpretationWindow.js
+++ b/src/ui/InterpretationWindow.js
@@ -2,7 +2,7 @@ import { SharingWindow } from './SharingWindow';
 
 export var InterpretationWindow;
 
-InterpretationWindow = function(c, sharing) {
+InterpretationWindow = function(c, sharing, interpretation, success) {
     var appManager = c.appManager,
         uiManager = c.uiManager,
         instanceManager = c.instanceManager,
@@ -19,6 +19,7 @@ InterpretationWindow = function(c, sharing) {
         fieldStyle: 'padding-left:3px; padding-top:3px',
         emptyText: i18n.write_your_interpretation + '..',
         enableKeyEvents: true,
+        value: interpretation ? interpretation.text : undefined,
         listeners: {
             keyup: function() {
                 shareButton.xable();
@@ -26,59 +27,76 @@ InterpretationWindow = function(c, sharing) {
         }
     });
 
-    var sharingCmp = new SharingWindow(c, sharing, true);
+    var sharingCmp = sharing ? new SharingWindow(c, sharing, true) : null;
 
     var sharingCt = Ext.create('Ext.container.Container', {
         style: 'padding-top:10px',
-        items: sharingCmp.items
+        items: sharingCmp ? sharingCmp.items : []
     });
 
+    var method = interpretation ? 'PUT' : 'POST';
+
+    var interpretationSuccess = function(text) {
+        if (interpretation) {
+            interpretation.text = text;
+        }
+        if (success) {
+            success();
+        } else {
+            instanceManager.getById(null, function(layout, isFavorite) {
+                instanceManager.getReport(layout, isFavorite, false, false, function() {
+                    uiManager.unmask();
+                });
+            });
+        }
+    };
+
+    var updateSharing = function(obj, text) {
+        var interpretationId = interpretation ? interpretation.id :
+                (obj.getResponseHeader('location') || '').split('/').pop(),
+            sharingId = sharing.object.id,
+            sharingBody = sharingCmp.getBody();
+
+        Ext.Ajax.request({
+            url: encodeURI(apiPath + '/sharing?type=interpretation&id=' + interpretationId),
+            method: method,
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            params: Ext.encode(sharingBody),
+            callback: function() {
+                Ext.Ajax.request({
+                    url: encodeURI(apiPath + '/sharing?type=' + apiResource + '&id=' + sharingId),
+                    method: "POST",
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    params: Ext.encode(sharingBody),
+                    callback: function() { interpretationSuccess(text); }
+                });
+            }
+        });
+    };
+
     var shareButton = Ext.create('Ext.button.Button', {
-        text: i18n.share,
-        disabled: true,
+        text: interpretation ? i18n.update : i18n.share,
+        disabled: !interpretation,
         xable: function() {
             this.setDisabled(!textArea.getValue());
         },
         handler: function() {
-            if (textArea.getValue()) {
+            var text = textArea.getValue();
+            var interpretationPath = interpretation ? '/interpretations/' + interpretation.id :
+                '/interpretations/' + apiResource + '/' + instanceManager.getStateFavoriteId();
+
+            if (text) {
                 Ext.Ajax.request({
-                    url: encodeURI(apiPath + '/interpretations/' + apiResource + '/' + instanceManager.getStateFavoriteId()),
-                    method: 'POST',
-                    params: textArea.getValue(),
+                    url: encodeURI(apiPath + interpretationPath),
+                    method: method,
+                    params: text,
                     headers: {'Content-Type': 'text/html'},
                     success: function(obj) {
-                        var interpretationId = (obj.getResponseHeader('location') || '').split('/').pop(),
-                            sharingId = sharing.object.id,
-                            sharingBody = sharingCmp.getBody();
-
-                        Ext.Ajax.request({
-                            url: encodeURI(apiPath + '/sharing?type=interpretation&id=' + interpretationId),
-                            method: 'POST',
-                            headers: {
-                                'Content-Type': 'application/json'
-                            },
-                            params: Ext.encode(sharingBody),
-                            callback: function() {
-                                Ext.Ajax.request({
-                                    url: encodeURI(apiPath + '/sharing?type=' + apiResource + '&id=' + sharingId),
-                                    method: 'POST',
-                                    headers: {
-                                        'Content-Type': 'application/json'
-                                    },
-                                    params: Ext.encode(sharingBody),
-                                    callback: function() {
-                                        instanceManager.getById(null, function(layout, isFavorite) {
-                                            instanceManager.getReport(layout, isFavorite, false, false, function() {
-                                                uiManager.unmask();
-                                            });
-                                        });
-                                    }
-                                });
-                            }
-                        });
-
-
-
+                        sharing ? updateSharing(obj, text) : interpretationSuccess(text);
                         textArea.reset();
                         window.destroy();
                     }

--- a/src/ui/Viewport.js
+++ b/src/ui/Viewport.js
@@ -4207,11 +4207,14 @@ Viewport = function(refs, cmp) {
                 }
             });
         },
-        setSidePanelsUIState: function(interpretationId){
+        setSidePanelsUIState: function(favoriteId, interpretationId){
             // If there is an interpretation loaded, collapse left panel and expand right panel
             if (interpretationId){
                 eastRegionButton.toggleCollapsePanel();
                 westRegionButton.toggleCollapsePanel();
+                if (favoriteId && interpretationId == "new") {
+                    eastRegion.openInterpretationWindow(favoriteId);
+                }
             }
         },
         tbar: {
@@ -4445,7 +4448,7 @@ Viewport = function(refs, cmp) {
                     layout;
 
                 if (id) {
-                    if (interpretationId) {
+                    if (interpretationId && interpretationId != "new") {
                         instanceManager.getById(id, function(layout) {
                             instanceManager.getInterpretationById(interpretationId, function(interpretation) {
                                 uiManager.updateInterpretation(interpretation, layout);
@@ -4465,7 +4468,7 @@ Viewport = function(refs, cmp) {
                 }
 
                 // Show/Collapse right and left panel
-                centerRegion.setSidePanelsUIState(interpretationId);
+                centerRegion.setSidePanelsUIState(id, interpretationId);
 
                 var initEl = document.getElementById('init');
                 initEl.parentNode.removeChild(initEl);


### PR DESCRIPTION
This PR implements some minor features and bug fixing regarding interpretations:
- Hide/show edit links for users without permissions
- Add 'Edit' and 'Delete' links both for interpretation and comments
![screenshot from 2017-05-04 13 47 18](https://cloud.githubusercontent.com/assets/6850223/25707548/d343bad4-30db-11e7-87fe-a7f81a0359fe.png)
- Improve user experience: post comment shows up from the beginning, show by default 500 chars of description instead of 200.
- Bug fixing: Allow read-only users to write an interpretation (hide bottom sharing section on write interpretation panel)
- Allows special interpretationid 'new' to open automatically a popup dialog (will be used by this [PR](https://github.com/dhis2/dhis2-core/pull/786))
- Bug fixing: Keep right side panel status while modifying a favourite

We have implemented two other PRs([charts](https://github.com/dhis2/charts-app/pull/31) and [pivots](https://github.com/dhis2/pivot-tables-app/pull/77)) with the strings. Please let us know if you want us to do anything regarding multilanguage.

@janhenrikoverland if you are happy with this we will create PRs for 2.26 and 2.27

Thank you!