### PR TITLE
Fix eastregion keep info on updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-analysis",
-  "version": "25.0.14",
+  "version": "25.0.15",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/api/Layout.js
+++ b/src/api/Layout.js
@@ -64,9 +64,7 @@ Layout = function(refs, c, applyConfig, forceApplyConfig) {
     t.name = arrayClean([c.displayName, c.displayShortName, c.name, c.shortName]).find(item => isString(item));
 
         // title
-    if (isString(c.title)) {
-        t.title = c.title;
-    }
+    t.title = arrayClean([c.displayShortName, c.title]).find(item => isString(item));
 
         // description
     if (isString(c.description)) {

--- a/src/manager/InstanceManager.js
+++ b/src/manager/InstanceManager.js
@@ -148,9 +148,9 @@ InstanceManager.prototype.getById = function(id, fn) {
             new t.api.Request({
                 baseUrl: appManager.getApiPath() + '/sharing',
                 type: 'json',
-                complete: function(sharing) {
+                complete: function(sharing, statusText, xhr) {
                     var permissions = {200: "write", 403: "read", 404: "none"};
-                    var permission = permissions[sharing.status] || "none";
+                    var permission = permissions[xhr.status] || "none";
                     var layout = new t.api.Layout(t.refs, r, {permission: permission});
                     if (layout) {
                         fn(layout, true);

--- a/src/manager/InstanceManager.js
+++ b/src/manager/InstanceManager.js
@@ -105,7 +105,7 @@ InstanceManager = function(refs) {
     };
 };
 
-InstanceManager.prototype.getLayout = function(layoutConfig) {
+InstanceManager.prototype.getLayout = function(layoutConfig, fromFavorite) {
     var t = this,
         favorite = t.getStateFavorite(),
         layout;
@@ -115,7 +115,9 @@ InstanceManager.prototype.getLayout = function(layoutConfig) {
     layout = new t.api.Layout(t.refs, layoutConfig);
 
     if (layout) {
-        layout.apply(favorite);
+        layout = favorite && fromFavorite ? 
+            favorite.apply(layout, Object.keys(layout)) : 
+            layout.apply(favorite);
     }
 
     return layout;
@@ -332,7 +334,7 @@ InstanceManager.prototype.getReport = function(layout, isFavorite, skipState, fo
 
     // layout
     if (!layout) {
-        layout = t.getLayout();
+        layout = t.getLayout(undefined, true);
 
         if (!layout) {
             return;

--- a/src/ui/EastRegion.js
+++ b/src/ui/EastRegion.js
@@ -50,7 +50,7 @@ EastRegion = function(c) {
         // Favorite loaded ->  Add favorite detail panel and update
         // Otherwise -> Display No Favorite Panel
         var detailsPanelItems;
-        if (instanceManager.isStateFavorite() && !instanceManager.isStateDirty()) {
+        if (instanceManager.isStateFavorite()) {
 
             var moreText = i18n.show_more;
             var lessText = i18n.show_less;
@@ -261,7 +261,6 @@ EastRegion = function(c) {
         itemId: 'detailsPanel',
 
         addAndUpdateFavoritePanel: function(layout) {
-
             // Remove any previous panel
             this.removeAll(true);
 
@@ -939,13 +938,11 @@ EastRegion = function(c) {
         items: [detailsPanel, interpretationsPanel],
         cls: 'eastPanel',
         setState: function(layout) {
-            if (layout.interpretations) {
-                this.getComponent('detailsPanel').addAndUpdateFavoritePanel(layout);
+            this.getComponent('detailsPanel').addAndUpdateFavoritePanel(layout);
 
-                // Favorite loaded with interpretations ->  Add interpretation panel and update
-            
-                this.getComponent('interpretationsPanel').addAndUpdateInterpretationsPanel(layout);
-            }
+            // Favorite loaded with interpretations ->  Add interpretation panel and update
+    
+            this.getComponent('interpretationsPanel').addAndUpdateInterpretationsPanel(layout);
         },
         listeners: {
             expand: function() {

--- a/src/ui/EastRegion.js
+++ b/src/ui/EastRegion.js
@@ -261,6 +261,7 @@ EastRegion = function(c) {
         itemId: 'detailsPanel',
 
         addAndUpdateFavoritePanel: function(layout) {
+
             // Remove any previous panel
             this.removeAll(true);
 


### PR DESCRIPTION
It works like this: on updates, getReport(layout, ...) is called without layout. In this case, we now use the current favourite as base object and apply the current layout over. This way, the render has the changes requested on the update (new elements, options, etc) but also keeps the favourite info and interpretations. Tested all favourite actions (save/save-as/new/...), it works fine.