### PR TITLE
Update arguments complete callback to work with jquery 3

### DIFF
--- a/src/manager/InstanceManager.js
+++ b/src/manager/InstanceManager.js
@@ -146,9 +146,9 @@ InstanceManager.prototype.getById = function(id, fn) {
             new t.api.Request({
                 baseUrl: appManager.getApiPath() + '/sharing',
                 type: 'json',
-                complete: function(sharing) {
+                complete: function(sharing, statusText, xhr) {
                     var permissions = {200: "write", 403: "read", 404: "none"};
-                    var permission = permissions[sharing.status] || "none";
+                    var permission = permissions[xhr.status] || "none";
                     var layout = new t.api.Layout(t.refs, r, {permission: permission});
                     if (layout) {
                         fn(layout, true);


### PR DESCRIPTION
Original report: https://jira.dhis2.org/browse/DHIS2-1893

The update of jquery from 1.8.2 to 3.2.0 in charts/pivot broke the _complete_ callback of `$.getJSON` (it was `(xhr, status)`, now it's `(data, status, xhr)`).