### PR TITLE
Port interpretations improvements from 2.25 branch

### DIFF
--- a/src/api/Layout.js
+++ b/src/api/Layout.js
@@ -128,6 +128,11 @@ Layout = function(refs, c, applyConfig, forceApplyConfig) {
         t.publicAccess = c.publicAccess;
     }
 
+        //permission
+    if (isString(c.permission)) {
+        t.permission = c.permission;
+    }
+
         //user group accesses
     if (arrayFrom(c.userGroupAccesses).length) {
         t.userGroupAccesses = c.userGroupAccesses;
@@ -444,6 +449,7 @@ Layout.prototype.toPlugin = function(el) {
             'created',
             'user',
             'publicAccess',
+            'permission',
             'userGroupAccesses',
             'prototype',
             'url'
@@ -550,6 +556,7 @@ Layout.prototype.toPostSuper = function() {
     delete this.created;
     delete this.user;
     delete this.publicAccess;
+    delete this.permission,
     delete this.userGroupAccesses;
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ import { WestRegionTrackerItems } from './ui/WestRegionTrackerItems.js';
 
 import { i18nInit } from './init/i18nInit.js';
 import { authViewUnapprovedDataInit } from './init/authViewUnapprovedDataInit.js';
+import { isAdminInit } from './init/isAdminInit.js';
 import { rootNodesInit } from './init/rootNodesInit.js';
 import { organisationUnitLevelsInit } from './init/organisationUnitLevelsInit.js';
 import { legendSetsInit } from './init/legendSetsInit.js';
@@ -124,6 +125,7 @@ export {
 
     i18nInit,
     authViewUnapprovedDataInit,
+    isAdminInit,
     rootNodesInit,
     organisationUnitLevelsInit,
     legendSetsInit,
@@ -210,6 +212,7 @@ export const ui = {
 export const init = {
     i18nInit,
     authViewUnapprovedDataInit,
+    isAdminInit,
     rootNodesInit,
     organisationUnitLevelsInit,
     legendSetsInit,

--- a/src/init/isAdminInit.js
+++ b/src/init/isAdminInit.js
@@ -1,0 +1,16 @@
+export var isAdminInit;
+
+isAdminInit = function(c) {
+    var t = this,
+        appManager = c.appManager,
+        requestManager = c.requestManager,
+        apiPath = appManager.getApiPath();
+
+    return {
+        baseUrl: appManager.getPath() + '/api/me/authorization/ALL', 
+        success: function(r) {
+            appManager.isAdmin = r;
+            requestManager.ok(this);
+        }
+    };
+};

--- a/src/manager/AppManager.js
+++ b/src/manager/AppManager.js
@@ -31,7 +31,7 @@ AppManager = function(refs) {
 
     t.defaultAnalysisFields = [
         '*',
-        'interpretations[*,user[id,displayName],likedBy[id,displayName],comments[lastUpdated,text,user[id,displayName]]]',
+        'interpretations[*,user[id,displayName],likedBy[id,displayName],comments[id,lastUpdated,text,user[id,displayName]]]',
         'columns[dimension,filter,legendSet[id],items[dimensionItem~rename(id),dimensionItemType,$]]',
         'rows[dimension,filter,legendSet[id],items[dimensionItem~rename(id),dimensionItemType,$]]',
         'filters[dimension,filter,items[dimensionItem~rename(id),dimensionItemType,$]]',

--- a/src/manager/UiManager.js
+++ b/src/manager/UiManager.js
@@ -154,8 +154,8 @@ UiManager = function(refs) {
         updateFn(content, elementId);
     };
 
-    t.updateInterpretation = function(interpretation) {
-        updateInterpretationFn(interpretation);
+    t.updateInterpretation = function(interpretation, layout) {
+        updateInterpretationFn(interpretation, layout);
     };
 
     // state
@@ -169,7 +169,7 @@ UiManager = function(refs) {
 
             // set url state
             if (favoriteState) {
-                t.setUrlState(('?id=' + favoriteState.id) + (favoriteState.interpretationId ? '&interpretationId=' + favoriteState.interpretationId : ''));
+                t.setUrlState(('?id=' + favoriteState.id) + (favoriteState.interpretationId ? '&interpretationid=' + favoriteState.interpretationId : ''));
             }
             else {
                 t.setUrlState('.');
@@ -520,6 +520,18 @@ UiManager = function(refs) {
 
     t.confirmCustom = function(title, msg, btnText, fn, applyConfig) {
         ConfirmWindow(refs, title, msg, btnText, fn, applyConfig).show();
+    };
+
+    t.confirmInterpretationDelete = function(fn) {
+        var i18n = t.i18nManager ? t.i18nManager.get() : {};
+        ConfirmWindow(refs, i18n.are_you_sure,
+            i18n.this_interpretation_will_be_deleted_continue, null, fn).show();
+    };
+
+    t.confirmCommentDelete = function(fn) {
+        var i18n = t.i18nManager ? t.i18nManager.get() : {};
+        ConfirmWindow(refs, i18n.are_you_sure,
+            i18n.this_comment_will_be_deleted_continue, null, fn).show();
     };
 
     // redirect

--- a/src/ui/Viewport.js
+++ b/src/ui/Viewport.js
@@ -493,6 +493,17 @@ Viewport = function(refs, cmp, config) {
         setScroll: function(fn) {
             this.onScroll = fn;
         },
+        setSidePanelsUIState: function(favoriteId, interpretationId) {
+            // If there is an interpretation loaded, collapse left panel and expand right panel
+            if (interpretationId) {
+                Ext.getCmp('toggleEastRegionButton').handler();
+                Ext.getCmp('toggleWestRegionButton').handler();
+
+                if (favoriteId && interpretationId == "new") {
+                    eastRegion.openInterpretationWindow(favoriteId);
+                }
+            }
+        },
         scrollTo: function(x, y) {
             this.body.scrollTo(x, y);
         },
@@ -503,6 +514,7 @@ Viewport = function(refs, cmp, config) {
             },
             items: [
                 {
+                    id: "toggleWestRegionButton",
                     text: ' ',
                     width: 26,
                     padding: '3',
@@ -538,6 +550,7 @@ Viewport = function(refs, cmp, config) {
                 '->',
                 ...integrationButtons,
                 {
+                    id: "toggleEastRegionButton",
                     text: ' ',
                     width: 26,
                     padding: '3',
@@ -669,11 +682,11 @@ Viewport = function(refs, cmp, config) {
                 // look for url params
                 var id = appManager.getUrlParam('id'),
                     session = appManager.getUrlParam('s'),
-                    interpretationId = appManager.getUrlParam('interpretationId'),
+                    interpretationId = appManager.getUrlParam('interpretationid'),
                     layout;
 
                 if (id) {
-                    if (interpretationId) {
+                    if (interpretationId && interpretationId != "new") {
                         instanceManager.getById(id, function(layout) {
                             instanceManager.getInterpretationById(interpretationId, function(interpretation) {
                                 uiManager.updateInterpretation(interpretation, layout);
@@ -697,6 +710,8 @@ Viewport = function(refs, cmp, config) {
 
                 Ext.getBody().setStyle('background', '#fff');
                 Ext.getBody().setStyle('opacity', 0);
+
+                centerRegion.setSidePanelsUIState(id, interpretationId);
 
                 // fade in
                 Ext.defer( function() {


### PR DESCRIPTION
Port interpretations improvements from 2.25 branch. No new functionality added, pretty much what we have in 2.25 that was never migrated.

[This bit of the code](https://github.com/dhis2/d2-analysis/compare/master...EyeSeeTea:2.28?expand=1#diff-2fe79a3901334425c2a6ccc1678eacf2R168) is a bit hacky. In order to get the user permissions for this favourite, we send an empty patch to the API. Depending on the user permissions, links ('Edit description','Edit Sharing') are displayed or hidden.If 200 -> show edit buttons, otherwise -> hide them.

The other two options we can think of are:
1) Calculate permissions locally:
Edit permissions = currentUser is SUPERADMIN [OR] favorite.sharing_public is READ_WRITE [OR] favorite.userGroups currentUser.userGroups

2) Always display the links and handle 403 exception

cc @tokland