### PR TITLE
re-add id for east region

### DIFF
--- a/src/ui/Viewport.js
+++ b/src/ui/Viewport.js
@@ -86,6 +86,7 @@ Viewport = function(refs, cmp, config) {
     var DownloadButtonItems = cmp.DownloadButtonItems;
 
     var detailsButton = Ext.create('Ext.Button', {
+        id: "toggleEastRegionButton",
         text: ' ',
         width: 26,
         padding: '3',


### PR DESCRIPTION
This PR solves a bug regarding the redirection from the dashboard to a pivot/chart/event/etc app with an interpretation loaded on init. Basically, if there is an interpretationid in the URL the app doesn't load properly and a blank page is loaded.

How to test:
Case 1: https://play.dhis2.org/dev/dhis-web-visualizer/index.html?id=HDEDqV3yv3H&interpretationid=FnIHFs31Fwe
Case 2: Go to Dashboard / Click the interpretation icon / Click on "share interpretation" /  Blank Page

