### PR TITLE
spell(Months): using full name instead on short name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2-analysis",
-  "version": "29.0.4",
+  "version": "29.0.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/api/Period.js
+++ b/src/api/Period.js
@@ -1367,7 +1367,7 @@ Period.prototype.generateDisplayProperties = function() {
     var p = this;
 
     var id = p.id,
-        months = 'Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec'.split('|'),
+        months = 'January|February|March|April|May|June|July|August|September|October|November|December'.split('|'),
         offset = parseInt(p.year) - (new Date()).getFullYear(),
         generator = refs.calendarManager.generator,
         getSuffix = function(array) {


### PR DESCRIPTION
- Probable fix for DHIS2-1797
- Full names are shown in Period's left column
- Favorites use short names for date display

![selection_596](https://user-images.githubusercontent.com/34527/36381797-04555c1e-1587-11e8-8c77-1670b8bf6d69.png)
