### PR TITLE
[interpretations] Show all messages on comments panel

### DIFF
--- a/src/ui/EastRegion.js
+++ b/src/ui/EastRegion.js
@@ -487,7 +487,7 @@ EastRegion = function(c) {
                         listeners: {
                             'render': function(label) {
                                 label.getEl().on('click', function() {
-                                    numberOfCommentsToDisplay += 3;
+                                    numberOfCommentsToDisplay = comments.length;
                                     this.up('#interpretationPanel' + interpretation.id).updateInterpretationPanelItems();
                                 }, label);
                             }
@@ -954,6 +954,7 @@ EastRegion = function(c) {
         collapsible: true,
         collapseMode: 'mini',
         collapsed: true,
+        autoScroll: true,
         border: false,
         width: uiConfig.west_width + uiManager.getScrollbarSize().width,
         items: [detailsPanel, interpretationsPanel],


### PR DESCRIPTION
Make link `[N more comments]` in EastRegion/interpretations show all the comments, not 3 more as it is now. 

Also, set `autoScroll: true` so the panel can be scrolled vertically on overflow (is this the best way?)

![b](https://user-images.githubusercontent.com/24643/37458960-e8f3d536-2846-11e8-81f4-752aae8df430.png)
