### PR TITLE
Limit max users to show in mentions window to 50

### DIFF
--- a/src/ui/MentionToolbar.js
+++ b/src/ui/MentionToolbar.js
@@ -18,9 +18,15 @@ MentionToolbar = function (refs) {
         zIndex: 9999,
         cls: 'mentions',
         createMentionLabelsForUser : function(users, splitText, currentMention, component){
+            const currentMentionLowerCase = currentMention.toLowerCase();
+
             return users
-                    .filter(user => (user.userCredentials.username.toLowerCase().includes(currentMention.toLowerCase()) || user.displayName.toLowerCase().includes(currentMention.toLowerCase())))
-                    .map((user) => {
+                    .filter(user => (
+                        user.userCredentials.username.toLowerCase().includes(currentMentionLowerCase) ||
+                        user.displayName.toLowerCase().includes(currentMentionLowerCase)
+                    ))
+                    .slice(0, 50)
+                    .map(user => {
                         return {
                             xtype: 'label',
                             html:  user.displayName + " (" + user.userCredentials.username + ")",


### PR DESCRIPTION
Issue => https://jira.dhis2.org/browse/DHIS2-4619
Problem => Classic apps (EV/DV/PT/ER) takes too much time to suggest users when mentioning in large DB
Solution => Display the first 50 users (as in Maps app).

cc @tokland 