### PR TITLE
Remove initial requests for mentions

### DIFF
--- a/src/manager/AppManager.js
+++ b/src/manager/AppManager.js
@@ -100,9 +100,6 @@ AppManager = function(refs) {
     t.periodGenerator;
     t.viewUnapprovedData;
 
-    t.users = [];
-    t.mostMentionedUsers = [];
-
     t.rootNodes = [];
     t.organisationUnitLevels = [];
     t.dimensions = [];

--- a/src/manager/AppManager.js
+++ b/src/manager/AppManager.js
@@ -236,95 +236,11 @@ AppManager.prototype.init = function(callbackFn) {
                 if (callbackFn) {
                     callbackFn();
                 }
-
-                usersReq();
-                
             }
         }).run();
     };
 
     manifestReq();
-
-    // users
-    const usersReq = () => {
-        new t.refs.api.Request(t.refs, {
-            baseUrl: t.getApiPath() + '/users.json',
-            type: 'json',
-            params: [
-                'fields=displayName,userCredentials[username]',
-                'order=displayName:asc',
-                'paging=false'
-            ],
-            success: function (response) {
-                t.users = response.users;
-                mostMentionedUsersInterpretationReq();
-            }
-        }).run();
-    };
-
-    // most mentioned users in interpretation
-    const mostMentionedUsersInterpretationReq = () => {
-        new t.refs.api.Request(t.refs, {
-            baseUrl: t.getApiPath() + '/interpretations.json',
-            type: 'json',
-            params: [
-                'fields=id,mentions',
-                'filter=user.id:eq:' + t.userAccount.id,
-                'filter=mentions:!null',
-                'paging=false'
-            ],
-            success: function (response) {
-                mostMentionedUsersInterpretationCommentReq(response)
-            }
-        }).run();
-    };
-
-    // most mentioned users in interpretation comment
-    const mostMentionedUsersInterpretationCommentReq = (previousResponse) => {
-
-        new t.refs.api.Request(t.refs, {
-            baseUrl: t.getApiPath() + '/interpretations.json',
-            type: 'json',
-            params: [
-                'fields=id,comments[mentions]',
-                'filter=comments.user.id:eq:' + t.userAccount.id,
-                'filter=comments.mentions.username:!null',
-                'paging=false'
-            ],
-            success: function (response) {
-                // Get users-mentions map
-                var usersByMentions = {}
-                previousResponse.interpretations.forEach( interpretation => 
-                    interpretation.mentions.forEach(mention => {
-                        usersByMentions[mention.username] = (usersByMentions[mention.username] || 0) + 1;
-
-                    })
-                );
-                response.interpretations.forEach( interpretation =>
-                    interpretation.comments.forEach (comment =>
-                        comment.mentions.forEach(mention => {
-                            usersByMentions[mention.username] = (usersByMentions[mention.username] || 0) + 1;
-                        }
-                    ))
-                );
-
-                // Sort users by mentions
-                var usernamesByMentions = Object.keys(usersByMentions).sort( function(a,b) {
-                    return usersByMentions[b] - usersByMentions[a];
-                });
-               
-                // Get real user object (No foreign key in jsonb object)
-                var usersByUsername = {};
-                t.users.forEach(user => usersByUsername[user.userCredentials.username] = user);
-                t.mostMentionedUsers = usernamesByMentions.map(username => usersByUsername[username]);
-
-                // Remove most mentioned users from users
-                t.users = t.users.filter( user => {
-                    return !t.mostMentionedUsers.includes(user);
-                });
-            }
-        }).run();
-    };
 };
 
 AppManager.prototype.logVersion = function() {

--- a/src/ui/MentionToolbar.js
+++ b/src/ui/MentionToolbar.js
@@ -8,6 +8,21 @@ MentionToolbar = function (refs) {
     
     var i18n = i18nManager.get();
 
+    var usersReq = function(search, onSuccess) {
+        new refs.api.Request(refs, {
+            baseUrl: appManager.getApiPath() + '/users.json',
+            type: 'json',
+            params: [
+                'query=' + search,
+                'fields=displayName,userCredentials[username]',
+                'order=displayName:asc',
+            ],
+            success: function(response) {
+                onSuccess(response.users);
+            },
+        }).run();
+    };
+
     var mentionsPanel = Ext.create('Ext.panel.Panel', {
         floating: true,
         layout: {
@@ -17,9 +32,8 @@ MentionToolbar = function (refs) {
         items: [],
         zIndex: 9999,
         cls: 'mentions',
-        createMentionLabelsForUser : function(users, splitText, currentMention, component){
+        createMentionLabelsForUser: function(users, splitText, component) {
             return users
-                    .filter(user => (user.userCredentials.username.toLowerCase().includes(currentMention.toLowerCase()) || user.displayName.toLowerCase().includes(currentMention.toLowerCase())))
                     .map((user) => {
                         return {
                             xtype: 'label',
@@ -43,38 +57,26 @@ MentionToolbar = function (refs) {
             // Split by @ and take last bit
             var splitText = text.split('@');
             var currentMention = splitText[splitText.length -1];
-            if (splitText.length > 1 && currentMention == currentMention.replace(" ", "").replace(/(?:\r\n|\r|\n)/g, "")){
-    
-                mentionsPanel.removeAll(true);
-    
-                var potentialMostMentionedUsers= this.createMentionLabelsForUser(appManager.mostMentionedUsers, splitText, currentMention, component);
-                var potentialUsers = this.createMentionLabelsForUser(appManager.users, splitText, currentMention, component);
-    
-                if (potentialMostMentionedUsers && potentialMostMentionedUsers.length > 0){
-                    mentionsPanel.add({
-                        html: i18n.most_common_users_matching + ' @' + currentMention,
-                        cls: 'mentionsTitle',
-                    });
-                    mentionsPanel.add(potentialMostMentionedUsers);
-                    
-                }
-                if (potentialUsers && potentialUsers.length > 0){
-                    mentionsPanel.add({
-                        html: i18n.other_users_matching + ' @' + currentMention,
-                        cls: 'mentionsTitle',
-                    });
-                    mentionsPanel.add(potentialUsers);
-                }
-    
-                if (potentialMostMentionedUsers && potentialMostMentionedUsers.length == 0 && potentialUsers && potentialUsers.length == 0){
-                    mentionsPanel.hide();
-                }
-                else{
-                    mentionsPanel.show().alignTo(event.target,'bl-tl');
-                }    
-    
+
+            if (splitText.length > 1 && currentMention == currentMention.replace(" ", "").replace(/(?:\r\n|\r|\n)/g, "")) {
+                usersReq(currentMention, users => {
+                    mentionsPanel.removeAll(true);
+
+                    var userLabels = this.createMentionLabelsForUser(users, splitText, component);
+        
+                    if (userLabels.length === 0) {
+                        mentionsPanel.hide();
+                    } else {
+                        mentionsPanel.add({
+                            html: i18n.users_matching + ' @' + currentMention,
+                            cls: 'mentionsTitle',
+                        });
+                        mentionsPanel.add(userLabels);
+                        mentionsPanel.show().alignTo(event.target,'bl-tl');
+                    }
+                });
             }
-            else{
+            else {
                 mentionsPanel.hide();
             }
         },

--- a/src/ui/MentionToolbar.js
+++ b/src/ui/MentionToolbar.js
@@ -32,6 +32,8 @@ MentionToolbar = function (refs) {
         items: [],
         zIndex: 9999,
         cls: 'mentions',
+        _lastText: null,
+        _isOpen: false,
         createMentionLabelsForUser: function(users, splitText, component) {
             return users
                     .map((user) => {
@@ -51,15 +53,21 @@ MentionToolbar = function (refs) {
                         }
                     });
         },
-        displayMentionSuggestion : function(component, event) {
+        displayMentionSuggestion: function(component, event) {
             // Get text from 0 to cursor position
             var text = component.getValue().substring(0,$(event.target).prop("selectionStart"));
+            if (text === this._lastText)
+                return;
+            this._lastText = text;
             // Split by @ and take last bit
             var splitText = text.split('@');
             var currentMention = splitText[splitText.length -1];
 
             if (splitText.length > 1 && currentMention == currentMention.replace(" ", "").replace(/(?:\r\n|\r|\n)/g, "")) {
+                this._isOpen = true;
                 usersReq(currentMention, users => {
+                    if (!this._isOpen)
+                        return;
                     mentionsPanel.removeAll(true);
 
                     var userLabels = this.createMentionLabelsForUser(users, splitText, component);
@@ -77,6 +85,7 @@ MentionToolbar = function (refs) {
                 });
             }
             else {
+                this._isOpen = false;
                 mentionsPanel.hide();
             }
         },


### PR DESCRIPTION
### :pushpin: References

* **JIRA Issue:** https://jira.dhis2.org/browse/DHIS2-2797

* Translations (master):

- https://github.com/dhis2/charts-app/pull/53
- https://github.com/dhis2/pivot-tables-app/pull/101
- https://github.com/dhis2/event-charts-app/pull/19
- https://github.com/dhis2/event-reports-app/pull/25

* Translations (v30):

- https://github.com/dhis2/charts-app/pull/54
- https://github.com/dhis2/pivot-tables-app/pull/102
- https://github.com/dhis2/event-charts-app/pull/20
- https://github.com/dhis2/event-reports-app/pull/26

### :memo: Implementation

- As discussed, the feature "most mentioned users" has been removed.
- All initial requests required for mentioning can now be removed: 1 /users + 2 /interpretations.
- A (paginated) request to /users?query=VALUE is performed instead on every search.