### PR TITLE
Fix: Event Report - Update button retrieves max 50 option values for filters

### DIFF
--- a/src/ux/GroupSetContainer.js
+++ b/src/ux/GroupSetContainer.js
@@ -52,6 +52,8 @@ GroupSetContainer = function(refs) {
 
             if (limit) {
                 params.push(`pageSize=${defaultPageSize}`);
+            } else {
+                params.push('paging=false');
             }
 
             if (filters) {


### PR DESCRIPTION
Fixes DHIS2-5146.

Steps to reproduce:
- Set up an Event Report  that includes a data element or attribute which uses an option set, and you set a filter with let us say 145 option values
- Save it as a favourite.
- Open favourite again in the Event Report app
- The code generated to retrieve the output result (ref console->network->XHR) will include all option values for that filter
- Click "Update"
- The same filter part of the XHR string will be truncated to the first 50 option values only.

Bug occurred when there were more than 50 options in data element filter.
This was caused by implicitly enabled API paging (50 per page).
