### PR TITLE
d2-ui-rich-text for favorite description, interpretations and comments (v30)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
   "homepage": "https://github.com/dhis2/d2-analysis#readme",
   "dependencies": {
     "@dhis2/d2-ui-rich-text": "^5.0.17",
-    "babel-loader": "6.4.1",
     "d2-utilizr": "^0.2.16",
-    "jquery": "2.1.4",
-    "json-loader": "^0.5.7"
+    "jquery": "2.1.4"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",
+    "babel-loader": "6.4.1",
     "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
-    "jest": "^21.2.1"
+    "jest": "^21.2.1",
+    "json-loader": "0.5.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/dhis2/d2-analysis#readme",
   "dependencies": {
-    "@dhis2/d2-ui-rich-text": "^5.0.17",
+    "@dhis2/d2-ui-rich-text": "^5.1.0",
     "d2-utilizr": "^0.2.16",
     "jquery": "2.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
     "jest": "^21.2.1",
-    "json-loader": "0.5.7"
+    "json-loader": "^0.5.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,11 @@
   },
   "homepage": "https://github.com/dhis2/d2-analysis#readme",
   "dependencies": {
+    "@dhis2/d2-ui-rich-text": "^5.0.17",
+    "babel-loader": "6.4.1",
     "d2-utilizr": "^0.2.16",
-    "jquery": "2.1.4"
+    "jquery": "2.1.4",
+    "json-loader": "^0.5.7"
   },
   "devDependencies": {
     "babel-cli": "^6.3.15",

--- a/src/ui/EastRegion.js
+++ b/src/ui/EastRegion.js
@@ -5,6 +5,8 @@ import {RenameWindow} from './RenameWindow.js';
 import {MentionToolbar } from './MentionToolbar.js';
 import {formatDate} from '../util/dateUtils.js';
 import arraySort from 'd2-utilizr/lib/arraySort';
+import MdParser from '@dhis2/d2-ui-rich-text/parser/MdParser';
+import {onMarkdownEditorKeyDown} from '../util/dom';
 
 export var EastRegion;
 
@@ -20,8 +22,14 @@ EastRegion = function(c) {
     var i18n = i18nManager.get(),
         path = appManager.getPath(),
         apiPath = appManager.getApiPath();
-
+    
     var descriptionMaxNumberCharacter = 500;
+
+    var mdParser = new MdParser();
+
+    var renderMd = function(plain) {
+        return '<span class="markdown"> ' + mdParser.render(plain) + '</span>';
+    }
 
     var openInterpretationWindow = function(id, interpretation, success) {
         var favoriteId = id || instanceManager.getStateFavoriteId();
@@ -146,7 +154,7 @@ EastRegion = function(c) {
                 descriptionItems.push({
                     xtype: 'label',
                     itemId: 'descriptionLabel',
-                    html: isTooLongDescription ? shortDescription : description,
+                    html: renderMd(isTooLongDescription ? shortDescription : description),
                     cls: 'interpretationActions'
                 });
 
@@ -421,7 +429,7 @@ EastRegion = function(c) {
                         itemId: 'commentArea',
                         cls: 'commentArea',
                         emptyText: i18n.write_your_interpretation,
-                        value : comment && comment.text,
+                        value: comment && comment.text,
                         submitEmptyText: false,
                         mentionToolbar: MentionToolbar(c),
                         flex: 1,
@@ -440,6 +448,7 @@ EastRegion = function(c) {
                                     commentInterpretation(f, comment);
                                 }
                             },
+                            keydown: onMarkdownEditorKeyDown,
                             keyup: function(f, e) {
                                 this.mentionToolbar.displayMentionSuggestion(f, e);
                             },
@@ -541,7 +550,7 @@ EastRegion = function(c) {
                             style: 'margin-top: 5px; margin-bottom: 6px;',
                             items: [{
                                 xtype: 'label',
-                                text: comment.text,
+                                html: renderMd(comment.text),
                             }],
                         }, {
                             xtype: 'label',
@@ -807,7 +816,7 @@ EastRegion = function(c) {
                 style: 'margin-bottom: 8px;',
                 items: [{
                     xtype: 'label',
-                    text: interpretation.text,
+                    html: renderMd(interpretation.text),
                 }]
             }, {
                 xtype: 'panel',

--- a/src/ui/EastRegion.js
+++ b/src/ui/EastRegion.js
@@ -22,7 +22,7 @@ EastRegion = function(c) {
     var i18n = i18nManager.get(),
         path = appManager.getPath(),
         apiPath = appManager.getApiPath();
-    
+
     var descriptionMaxNumberCharacter = 500;
 
     var mdParser = new MdParser();

--- a/src/ui/FavoriteTextCmp.js
+++ b/src/ui/FavoriteTextCmp.js
@@ -1,4 +1,5 @@
 import fs from './FavoriteStyle';
+import {onMarkdownEditorKeyDown} from '../util/dom';
 
 export default function({ layout, i18n }) {
 
@@ -48,7 +49,10 @@ export default function({ layout, i18n }) {
         labelSeparator: '',
         emptyText: 'No description (optional)',
         enableKeyEvents: true,
-        value: layout.description
+        value: layout.description,
+        listeners: {
+            keydown: onMarkdownEditorKeyDown,
+        },
     });
 
     const titleTextField = Ext.create('Ext.form.field.Text', {		

--- a/src/ui/InterpretationWindow.js
+++ b/src/ui/InterpretationWindow.js
@@ -1,5 +1,6 @@
 import { SharingWindow } from './SharingWindow';
 import { MentionToolbar } from './MentionToolbar.js';
+import {onMarkdownEditorKeyDown} from '../util/dom';
 
 export var InterpretationWindow;
 
@@ -26,6 +27,7 @@ InterpretationWindow = function(c, sharing, interpretation, success) {
                 shareButton.xable();
                 this.mentionToolbar.displayMentionSuggestion(f, e);
             },
+            keydown: onMarkdownEditorKeyDown,
             destroy: function(f, e) {
                 this.mentionToolbar.destroy();
             }

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -1,3 +1,5 @@
+import convertCtrlKey from '@dhis2/d2-ui-rich-text/editor/convertCtrlKey';
+
 export const isTargetDiv = elementId => !!document.getElementById(elementId);
 
 export const validateTargetDiv = (elementId, msg) => {
@@ -10,4 +12,15 @@ export const validateTargetDiv = (elementId, msg) => {
     }
 
     return true;
+};
+
+export const onMarkdownEditorKeyDown = function(f, e) {
+    convertCtrlKey(e.browserEvent, newValue => {
+        const textarea = e.target;
+        const prevCursorPos = textarea.selectionEnd;
+        textarea.value = newValue;
+        if (prevCursorPos) {
+            textarea.setSelectionRange(prevCursorPos + 1, prevCursorPos + 1);
+        }
+    });
 };

--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -15,12 +15,9 @@ export const validateTargetDiv = (elementId, msg) => {
 };
 
 export const onMarkdownEditorKeyDown = function(f, e) {
-    convertCtrlKey(e.browserEvent, newValue => {
+    convertCtrlKey(e.browserEvent, (newValue, newCursorPos) => {
         const textarea = e.target;
-        const prevCursorPos = textarea.selectionEnd;
         textarea.value = newValue;
-        if (prevCursorPos) {
-            textarea.setSelectionRange(prevCursorPos + 1, prevCursorPos + 1);
-        }
+        textarea.setSelectionRange(newCursorPos, newCursorPos);
     });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,15 @@
 # yarn lockfile v1
 
 
+"@dhis2/d2-ui-rich-text@^5.0.17":
+  version "5.0.17"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-5.0.17.tgz#bc16fb8c3b439f4d7e7bd0c9788858ddcab623f8"
+  integrity sha512-dulmBFIjFC5BhTmBJriPjxNNMocBzsSTQtromRlPJayrEwIHUOY700lTFrPH1kLzW0F+a/rkGSIWeM1ioQ9n/g==
+  dependencies:
+    babel-runtime "^6.26.0"
+    markdown-it "^8.4.2"
+    prop-types "^15.6.2"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -396,6 +405,16 @@ babel-jest@^21.2.0:
   dependencies:
     babel-plugin-istanbul "^4.0.0"
     babel-preset-jest "^21.2.0"
+
+babel-loader@6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-6.4.1.tgz#0b34112d5b0748a8dcdbf51acf6f9bd42d50b8ca"
+  integrity sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=
+  dependencies:
+    find-cache-dir "^0.1.1"
+    loader-utils "^0.2.16"
+    mkdirp "^0.5.1"
+    object-assign "^4.0.1"
 
 babel-messages@^6.22.0:
   version "6.22.0"
@@ -885,6 +904,11 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+big.js@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
+  integrity sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==
+
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
@@ -1053,6 +1077,11 @@ commander@^2.8.1, commander@^2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1187,6 +1216,16 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
+emojis-list@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
+  integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
+
+entities@~1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
+  integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+
 errno@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
@@ -1315,6 +1354,15 @@ fill-range@^2.1.0:
     randomatic "^1.1.3"
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
+
+find-cache-dir@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-0.1.1.tgz#c8defae57c8a52a8a784f9e31c57c742e993a0b9"
+  integrity sha1-yN765XyKUqinhPnjHFfHQumToLk=
+  dependencies:
+    commondir "^1.0.1"
+    mkdirp "^0.5.1"
+    pkg-dir "^1.0.0"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -2049,6 +2097,11 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
+"js-tokens@^3.0.0 || ^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+
 js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -2095,6 +2148,11 @@ jsesc@^1.3.0:
 jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
+
+json-loader@^0.5.7:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
+  integrity sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -2157,6 +2215,13 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+linkify-it@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.1.0.tgz#c4caf38a6cd7ac2212ef3c7d2bde30a91561f9db"
+  integrity sha512-4REs8/062kV2DSHxNfq5183zrqXMl7WP0WzABH9IeJI+NLm429FgE1PDecltYfnOoFDFlZGh2T8PfZn0r+GTRg==
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -2175,6 +2240,16 @@ load-json-file@^2.0.0:
     parse-json "^2.2.0"
     pify "^2.0.0"
     strip-bom "^3.0.0"
+
+loader-utils@^0.2.16:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
+  integrity sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
+    object-assign "^4.0.1"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -2225,6 +2300,13 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0"
 
+loose-envify@^1.3.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
+  integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
+  dependencies:
+    js-tokens "^3.0.0 || ^4.0.0"
+
 lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
@@ -2237,6 +2319,22 @@ makeerror@1.0.x:
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
   dependencies:
     tmpl "1.0.x"
+
+markdown-it@^8.4.2:
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
+  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~1.1.1"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 mem@^1.1.0:
   version "1.1.0"
@@ -2434,7 +2532,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -2601,6 +2699,13 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  integrity sha1-ektQio1bstYp1EcFb/TpyTFM89Q=
+  dependencies:
+    find-up "^1.0.0"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -2627,6 +2732,14 @@ private@^0.1.7:
 process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
+
+prop-types@^15.6.2:
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
+  integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
+  dependencies:
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -3207,6 +3320,11 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
+  integrity sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==
 
 uglify-js@^2.6:
   version "2.8.29"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@dhis2/d2-ui-rich-text@^5.0.17":
-  version "5.0.17"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-5.0.17.tgz#bc16fb8c3b439f4d7e7bd0c9788858ddcab623f8"
-  integrity sha512-dulmBFIjFC5BhTmBJriPjxNNMocBzsSTQtromRlPJayrEwIHUOY700lTFrPH1kLzW0F+a/rkGSIWeM1ioQ9n/g==
+"@dhis2/d2-ui-rich-text@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-5.1.0.tgz#87aa6e2214edbc5c686785ef717eef6f3e0d2e02"
+  integrity sha512-v9jARS9kJ0A9B8n3/vS7Gdyi1eB6hTYSkdEVi4tZvEMyVDzQjeEQhPZjRUo7r135KyNTh5zakp08ckLzgCu//A==
   dependencies:
     babel-runtime "^6.26.0"
     markdown-it "^8.4.2"


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes [DHIS2-5492](https://jira.dhis2.org/browse/DHIS2-5492) and [DHIS2-5494](https://jira.dhis2.org/browse/DHIS2-5494)

**Note:** First we'll create PRs for d2-analysis:v30 and dhis2-charts:v30. Once that is validated we will create PRs for the rest: PT/ER/EV * v31/master.

### :memo: Implementation

- Using [d2-ui-rich-text](https://www.npmjs.com/package/@dhis2/d2-ui-rich-text). This package was first written for React, but the key helper functions have been abstracted so it can be used anywhere.
- [webpack] We need babel-loader because the build code of d2-ui-rich-text is ES6.
- [webpack] We need json-loader because d2-ui-rich-text uses markdown-it, which loads a json with a `require.`
- Shortcuts control+b, control+i are supported using convertCtrlKey from d2-ui-rich-text.
- Added class `.markdown` to rendered html so styles can be overwritten.
- `onMarkdownEditorKeyDown`: d2-ui-rich-text does not provide info about the next desired cursor position, the problem has been reported.
- Analytic tools using this d2-analysis will need: 1) add @dhis2\/d2-ui-rich-text to babel transpiling, 2) Add json-loader to its webpack. 3) Use css class `.markdown` to override default ext.js styles.

### :art: Screenshots

![screenshot from 2019-01-18 10-43-45](https://user-images.githubusercontent.com/24643/51378892-72248980-1b0e-11e9-98de-f2f7bf286d89.png)
