### PR TITLE
Show 5 mentions at most and grey out users without read access to the favorite

### DIFF
--- a/src/ui/MentionToolbar.js
+++ b/src/ui/MentionToolbar.js
@@ -39,7 +39,7 @@ MentionToolbar = function (refs) {
         }).run();
     };
 
-    var disabledRowStyle = "display: block; background-color: white; color: grey; cursor: default";
+    var disabledRowStyle = "display: block; background-color: white; color: grey; cursor: not-allowed";
 
     var mentionsPanel = Ext.create('Ext.panel.Panel', {
         floating: true,
@@ -56,10 +56,13 @@ MentionToolbar = function (refs) {
             return users
                     .map((user) => {
                         const hasAccess = canUserAccessCurrentFavorite(user);
+                        const text = user.displayName +
+                            " (" + user.userCredentials.username + ")" +
+                            (hasAccess ? "" : (" - " + i18n.user_cannot_view));
 
                         return {
                             xtype: 'label',
-                            html:  user.displayName + " (" + user.userCredentials.username + ")",
+                            text: text,
                             style: hasAccess ? "" : disabledRowStyle,
                             listeners: !hasAccess ? {} : {
                                 'render': function(label) {


### PR DESCRIPTION
### :pushpin: References

* **Issue:** Closes https://jira.dhis2.org/browse/DHIS2-5483

### :memo: Implementation

- AFAIK, there is no way in the API to ask "can this user access this object according to the sharing?" (is there?). So I used `favorite.publicAccess`, `favorite.userAccesses`, and `favorite.userGroupAccesses` and match it with the user and its userGroups.
- The JIRA issue says "On comment reply, the comment author should be mentioned". This already works in my tests. Note the username only appears when answering other user comments. Also, some interpretations in play.dhis2 belong to non-existing users, it won't show a username in this case.

### :art: Screenshots

![screenshot from 2019-01-18 13-48-38](https://user-images.githubusercontent.com/24643/51387824-cab45080-1b27-11e9-847a-d196277912f1.png)
