### PR TITLE
fix: Load programs on app start to properly select program for opened AO

### DIFF
--- a/src/manager/AppManager.js
+++ b/src/manager/AppManager.js
@@ -36,6 +36,7 @@ AppManager = function(refs) {
         'columns[dimension,filter,legendSet[id],items[dimensionItem~rename(id),dimensionItemType,$]]',
         'rows[dimension,filter,legendSet[id],items[dimensionItem~rename(id),dimensionItemType,$]]',
         'filters[dimension,filter,legendSet[id],items[dimensionItem~rename(id),dimensionItemType,$]]',
+        'program[id,displayName~rename(name)]',
         'access',
         'userGroupAccesses',
         'publicAccess',

--- a/src/ui/WestRegionTrackerItems.js
+++ b/src/ui/WestRegionTrackerItems.js
@@ -3067,7 +3067,10 @@ WestRegionTrackerItems = function(refs) {
 
         if (layout) {
             // data
-            programStore.add(layout.program);
+            if (!programStore.getById(layout.program.id)) {
+                programStore.add(layout.program);
+            }
+
             program.setValue(layout.program.id);
 
             // periods

--- a/src/ui/WestRegionTrackerItems.js
+++ b/src/ui/WestRegionTrackerItems.js
@@ -80,6 +80,7 @@ WestRegionTrackerItems = function(refs) {
                 }
             },
         },
+        autoLoad: true
     });
 
     var stagesByProgramStore = Ext.create('Ext.data.Store', {
@@ -212,7 +213,7 @@ WestRegionTrackerItems = function(refs) {
         labelSeparator: '',
         emptyText: 'Select program',
         forceSelection: true,
-        queryMode: 'remote',
+        queryMode: 'local',
         columnWidth: 0.5,
         style: 'margin:1px 1px 1px 0',
         storage: {},


### PR DESCRIPTION
Fixes [DHIS2-5479](https://jira.dhis2.org/browse/DHIS2-5479).

Changes include:
- Enabling autoload for programs store on app start.
- Disable loading data on program's combobox expand