### PR TITLE
feat: use event report date label for events in ER

### DIFF
--- a/src/manager/AppManager.js
+++ b/src/manager/AppManager.js
@@ -37,6 +37,7 @@ AppManager = function(refs) {
         'rows[dimension,filter,legendSet[id],items[dimensionItem~rename(id),dimensionItemType,$]]',
         'filters[dimension,filter,legendSet[id],items[dimensionItem~rename(id),dimensionItemType,$]]',
         'program[id,displayName~rename(name)]',
+        'programStage[id,displayName~rename(name),executionDateLabel]',
         'access',
         'userGroupAccesses',
         'publicAccess',

--- a/src/table/EventDataTable.js
+++ b/src/table/EventDataTable.js
@@ -13,9 +13,20 @@ EventDataTable = function(refs, layout, response) {
 
     var i18n = i18nManager.get();
 
-    var FIXED_HEADERS = ['eventdate', 'enrollmentdate', 'incidentdate'];
+    var EVENT_DATE = 'eventdate';
+    var ENROLLMENT_DATE = 'enrollmentdate';
+    var INCIDENT_DATE = 'incidentdate';
+    var FIXED_HEADERS = [EVENT_DATE, ENROLLMENT_DATE, INCIDENT_DATE];
 
-    var filteredHeaders = response.getFilteredHeaders([].concat(FIXED_HEADERS, layout.getDimensionNames()));
+    var programStage = layout.programStage;
+    var eventDateLabel = programStage.executionDateLabel;
+
+    var filteredHeaders = response
+        .getFilteredHeaders([].concat(FIXED_HEADERS, layout.getDimensionNames()))
+        .map(header => header.name === EVENT_DATE
+            ? Object.assign({}, header, { column: eventDateLabel || header.column })
+            : header
+        );
 
     var rows = response.rows;
     var items = response.metaData.items;

--- a/src/ui/WestRegionTrackerItems.js
+++ b/src/ui/WestRegionTrackerItems.js
@@ -327,7 +327,7 @@ WestRegionTrackerItems = function(refs) {
                 params: [
                     'filter=id:eq:' + programId,
                     [
-                        'fields=programType,programStages[id,displayName~rename(name)]',
+                        'fields=programType,programStages[id,displayName~rename(name),executionDateLabel]',
                         'programIndicators[id,' + displayPropertyUrl + ']',
                         'programTrackedEntityAttributes[trackedEntityAttribute[id,' +
                             displayPropertyUrl +
@@ -400,6 +400,10 @@ WestRegionTrackerItems = function(refs) {
                 ? {
                       id: this.getValue(),
                       name: this.getRawValue(),
+                      executionDateLabel: this.getStore()
+                          .getById(this.getValue())
+                          .data
+                          .executionDateLabel
                   }
                 : null;
         },


### PR DESCRIPTION
Relates to [DHIS2-2757](https://jira.dhis2.org/browse/DHIS2-2757).

Changes include:
- Including program stage's executionDateLabel in response from API
- Use executionDateLabel as default label for event report date in events table.