### PR TITLE
fix: use correct aggregation type for downloading pivot table

### DIFF
--- a/src/api/Layout.js
+++ b/src/api/Layout.js
@@ -925,16 +925,16 @@ Layout.prototype.req = function(source, format, isSorted, isTableLayout, isFilte
         request.add('completedOnly=true');
     }
 
+    // aggregation type
+    if (isString(this.aggregationType) && this.aggregationType !== defAggTypeId) {
+        request.add('aggregationType=' + this.aggregationType);
+    }
+
     // normal request only
     if (!isTableLayout) {
         // hierarchy
         if (this.showHierarchy) {
             request.add('hierarchyMeta=true');
-        }
-
-        // aggregation type
-        if (isString(this.aggregationType) && this.aggregationType !== defAggTypeId) {
-            request.add('aggregationType=' + this.aggregationType);
         }
 
         // user org unit


### PR DESCRIPTION
Fixes [DHIS2-2651](https://jira.dhis2.org/browse/DHIS2-2651).

Changes include:
- Attaching corresponding aggregationType to URL for downloading regardless of table layout type. 