### PR TITLE
fix: re-expose user display name

### DIFF
--- a/src/manager/AppManager.js
+++ b/src/manager/AppManager.js
@@ -31,8 +31,8 @@ AppManager = function(refs) {
 
     t.defaultAnalysisFields = [
         '*',
-        'interpretations[*,user[id,displayName,userCredentials[username]],likedBy[id,displayName],' +
-            'comments[id,lastUpdated,text,user[id,displayName,userCredentials[username]]]]',
+        'interpretations[*,user[id,name::rename(displayName),userCredentials[username]],likedBy[id,displayName],' +
+            'comments[id,lastUpdated,text,user[id,name::rename(displayName),userCredentials[username]]]]',
         'columns[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,$]]',
         'rows[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,$]]',
         'filters[dimension,filter,programStage[id],legendSet[id],items[dimensionItem~rename(id),dimensionItemType,$]]',


### PR DESCRIPTION
DO NOT MERGE: wait for the name vs displayName decision to be made in the backend.

The web api no longer outputs `displayName` for users. Renaming `name` to `displayName` in the request makes it work without changing all the usage of it.