### PR TITLE
feat: add class-names for push-analytics

### DIFF
--- a/src/ui/ChartDownloadButtonItems.js
+++ b/src/ui/ChartDownloadButtonItems.js
@@ -17,6 +17,7 @@ ChartDownloadButtonItems = function(refs) {
         },
         {
             text: i18n.image_png + ' (.png)',
+            cls: 'downloadaspng-menuitem',
             iconCls: 'ns-menu-item-image',
             handler: function() {
                 uiManager.submitSvgForm('png', getFilename());

--- a/src/ui/ChartDownloadButtonItems.js
+++ b/src/ui/ChartDownloadButtonItems.js
@@ -17,7 +17,7 @@ ChartDownloadButtonItems = function(refs) {
         },
         {
             text: i18n.image_png + ' (.png)',
-            cls: 'downloadaspng-menuitem',
+            cls: 'push-analytics-download-as-png-menu-item',
             iconCls: 'ns-menu-item-image',
             handler: function() {
                 uiManager.submitSvgForm('png', getFilename());

--- a/src/ui/FavoriteButton.js
+++ b/src/ui/FavoriteButton.js
@@ -15,6 +15,7 @@ FavoriteButton = function(c) {
 
     return Ext.create('Ext.button.Button', {
         text: i18n.favorites,
+        cls: 'favorites-dropdownmenu-button',
         menu: {},
         handler: function(b) {
             b.menu = Ext.create('Ext.menu.Menu', {
@@ -28,6 +29,7 @@ FavoriteButton = function(c) {
 
                     var newItem = Ext.create('Ext.menu.Item', {
                         text: getTitle(i18n.new_),
+                        cls: 'neweventsreport-menuitem',
                         iconCls: 'ns-menu-item-favorite-new',
                         disabled: !instanceManager.isStateCurrent(),
                         handler: function() {

--- a/src/ui/FavoriteButton.js
+++ b/src/ui/FavoriteButton.js
@@ -15,7 +15,7 @@ FavoriteButton = function(c) {
 
     return Ext.create('Ext.button.Button', {
         text: i18n.favorites,
-        cls: 'favorites-dropdownmenu-button',
+        cls: 'push-analytics-favorites-dropdown-menu-button',
         menu: {},
         handler: function(b) {
             b.menu = Ext.create('Ext.menu.Menu', {
@@ -29,7 +29,7 @@ FavoriteButton = function(c) {
 
                     var newItem = Ext.create('Ext.menu.Item', {
                         text: getTitle(i18n.new_),
-                        cls: 'neweventsreport-menuitem',
+                        cls: 'push-analytics-new-events-report-menu-item',
                         iconCls: 'ns-menu-item-favorite-new',
                         disabled: !instanceManager.isStateCurrent(),
                         handler: function() {

--- a/src/ui/Viewport.js
+++ b/src/ui/Viewport.js
@@ -146,6 +146,7 @@ Viewport = function(refs, cmp, config) {
 
     var downloadButton = Ext.create('Ext.button.Button', {
         text: i18n.download,
+        cls: 'download-dropdownmenu-button',
         disabled: true,
         menu: {},
         handler: function(b) {

--- a/src/ui/Viewport.js
+++ b/src/ui/Viewport.js
@@ -146,7 +146,7 @@ Viewport = function(refs, cmp, config) {
 
     var downloadButton = Ext.create('Ext.button.Button', {
         text: i18n.download,
-        cls: 'download-dropdownmenu-button',
+        cls: 'push-analytics-download-dropdown-menu-button',
         disabled: true,
         menu: {},
         handler: function(b) {


### PR DESCRIPTION
This PR adds some class-names to elements which can be used by push-analytics to convert a visualization. Once this is merged and a new version of this lib is released, we'll need to also update https://github.com/dhis2/event-reports-app/pull/1241 and create a PR in the Event Charts App to bump it.