### PR TITLE
fix: fields comma issue + axis dimension labels

### DIFF
--- a/src/api/Response.js
+++ b/src/api/Response.js
@@ -128,6 +128,12 @@ export const Response = function(refs, config) {
         Object.keys(dimensions)
             .filter(key => key.includes('.'))
             .forEach(key => (dimensions[getSplitElementId(key)] = dimensions[key]));
+
+        var items = config.metaData.items;
+
+        Object.keys(items)
+            .filter(key => key.includes('.'))
+            .forEach(key => (items[getSplitElementId(key)] = items[key]));
     })();
 
     t.optionCodeIdMap = function() {

--- a/src/ui/WestRegionTrackerItems.js
+++ b/src/ui/WestRegionTrackerItems.js
@@ -454,7 +454,7 @@ WestRegionTrackerItems = function(refs) {
                             ',categoryOptions[id,' +
                             displayPropertyUrl +
                             ']]]',
-                    ].join(''),
+                    ].join(','),
                     'paging=false',
                 ],
                 success: function(r) {


### PR DESCRIPTION
Fix the issue with missing commas in field specifications.
Make sure axis dimension labels render names and not ids.